### PR TITLE
Adds summary information to most models

### DIFF
--- a/api/about-us/models/about-us.settings.json
+++ b/api/about-us/models/about-us.settings.json
@@ -5,22 +5,22 @@
   "info": {
     "name": "About Us",
     "description": "Contenido de la página de información acerca del observatorio",
-    "mainField": "Title"
+    "mainField": "title"
   },
   "options": {
     "increments": true,
     "timestamps": true
   },
   "attributes": {
-    "Title": {
+    "title": {
       "type": "string",
       "required": true
     },
-    "Description": {
-      "type": "richtext",
-      "required": true
+    "content": {
+      "required": true,
+      "type": "richtext"
     },
-    "Cover": {
+    "cover": {
       "model": "file",
       "via": "related",
       "plugin": "upload",

--- a/api/activity-category/models/activity-category.settings.json
+++ b/api/activity-category/models/activity-category.settings.json
@@ -5,7 +5,7 @@
   "info": {
     "name": "ActivityCategory",
     "description": "Categorías de las actividades",
-    "mainField": "Title"
+    "mainField": "title"
   },
   "options": {
     "increments": true,
@@ -16,9 +16,13 @@
     "comment": ""
   },
   "attributes": {
-    "Title": {
+    "title": {
       "required": true,
       "type": "string"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
     }
   }
 }

--- a/api/activity/models/Activity.settings.json
+++ b/api/activity/models/Activity.settings.json
@@ -15,33 +15,37 @@
     "comment": ""
   },
   "attributes": {
-    "Title": {
+    "title": {
       "required": true,
-      "type": "text"
+      "type": "string"
     },
-    "Location": {
-      "required": true,
-      "type": "text"
-    },
-    "Description": {
-      "required": true,
-      "type": "richtext"
-    },
-    "MainImage": {
+    "mainImage": {
       "model": "file",
       "via": "related",
       "plugin": "upload",
       "required": false
     },
-    "Category": {
-      "model": "activity-category"
+    "summary": {
+      "type": "text",
+      "required": true
     },
-    "ActivityDateTime": {
+    "content": {
+      "required": true,
+      "type": "richtext"
+    },
+    "location": {
+      "required": true,
+      "type": "text"
+    },
+    "dateTime": {
       "type": "datetime"
     },
-    "Slug": {
+    "category": {
+      "model": "activity-category"
+    },
+    "slug": {
       "type": "uid",
-      "targetField": "Title"
+      "targetField": "title"
     }
   }
 }

--- a/api/campaign/models/Campaign.settings.json
+++ b/api/campaign/models/Campaign.settings.json
@@ -15,41 +15,46 @@
     "comment": ""
   },
   "attributes": {
-    "Title": {
-      "type": "text",
+    "title": {
+      "type": "string",
       "required": true
     },
-    "LaunchDate": {
-      "type": "date",
-      "required": true
-    },
-    "MainImage": {
+    "mainImage": {
       "model": "file",
       "via": "related",
       "plugin": "upload",
       "required": false
     },
-    "AdditionalImages": {
+    "summary": {
+      "type": "text",
+      "required": true
+    },
+    "content": {
+      "type": "richtext",
+      "required": true
+    },
+    "launchDate": {
+      "type": "date",
+      "required": true
+    },
+    "additionalImages": {
       "collection": "file",
       "via": "related",
       "plugin": "upload",
       "required": false
     },
-    "Attachment": {
+    "attachment": {
       "model": "file",
       "via": "related",
       "plugin": "upload",
       "required": false
     },
-    "LawNumber": {
+    "lawNumber": {
       "type": "string"
     },
-    "Summary": {
-      "type": "richtext"
-    },
-    "Slug": {
+    "slug": {
       "type": "uid",
-      "targetField": "Title"
+      "targetField": "title"
     }
   }
 }

--- a/api/featured-content/models/featured-content.settings.json
+++ b/api/featured-content/models/featured-content.settings.json
@@ -4,28 +4,13 @@
   "collectionName": "featured_contents",
   "info": {
     "name": "FeaturedContent",
-    "description": "Contenido seleccionado para aparecer en la página principal",
-    "mainField": "Title"
+    "description": "Contenido seleccionado para aparecer en la página principal"
   },
   "options": {
     "increments": true,
     "timestamps": true
   },
   "attributes": {
-    "Title": {
-      "type": "string",
-      "required": true
-    },
-    "Summary": {
-      "type": "text",
-      "required": true
-    },
-    "Thumbnail": {
-      "model": "file",
-      "via": "related",
-      "plugin": "upload",
-      "required": false
-    },
     "Activity": {
       "model": "activity"
     },

--- a/api/media-presence/models/media-presence.settings.json
+++ b/api/media-presence/models/media-presence.settings.json
@@ -15,36 +15,40 @@
     "comment": ""
   },
   "attributes": {
-    "Title": {
-      "type": "text",
+    "title": {
+      "type": "string",
       "required": true
     },
-    "Content": {
-      "default": "Texto de la noticia",
-      "required": true,
-      "type": "richtext"
-    },
-    "MainImage": {
+    "mainImage": {
       "model": "file",
       "via": "related",
       "plugin": "upload",
       "required": false
     },
-    "Source": {
-      "required": true,
-      "type": "string"
-    },
-    "SourceLink": {
+    "summary": {
       "type": "text",
       "required": true
     },
-    "PublicationDate": {
+    "content": {
+      "default": "Texto de la noticia",
+      "required": true,
+      "type": "richtext"
+    },
+    "source": {
+      "required": true,
+      "type": "string"
+    },
+    "sourceLink": {
+      "type": "text",
+      "required": true
+    },
+    "publicationDate": {
       "required": true,
       "type": "date"
     },
-    "Slug": {
+    "slug": {
       "type": "uid",
-      "targetField": "Title"
+      "targetField": "title"
     }
   }
 }

--- a/api/report-category/models/report-category.settings.json
+++ b/api/report-category/models/report-category.settings.json
@@ -5,7 +5,7 @@
   "info": {
     "name": "ReportCategory",
     "description": "Categorias para seleccionar en los informes",
-    "mainField": "Title"
+    "mainField": "title"
   },
   "options": {
     "increments": true,
@@ -16,10 +16,14 @@
     "comment": ""
   },
   "attributes": {
-    "Title": {
+    "title": {
       "type": "string",
       "unique": true,
       "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
     }
   }
 }

--- a/api/report/models/Report.settings.json
+++ b/api/report/models/Report.settings.json
@@ -15,49 +15,53 @@
     "comment": ""
   },
   "attributes": {
-    "Title": {
+    "title": {
       "required": true,
-      "type": "text"
+      "type": "string"
     },
-    "Summary": {
+    "mainImage": {
+      "model": "file",
+      "via": "related",
+      "plugin": "upload",
+      "required": false
+    },
+    "summary": {
+      "type": "text",
+      "required": true
+    },
+    "content": {
       "required": true,
       "type": "richtext"
     },
-    "MainImage": {
+    "attachment": {
       "model": "file",
       "via": "related",
       "plugin": "upload",
       "required": false
     },
-    "Attachment": {
-      "model": "file",
-      "via": "related",
-      "plugin": "upload",
-      "required": false
-    },
-    "FromDate": {
+    "fromDate": {
       "type": "date",
       "required": true
     },
-    "ToDate": {
+    "toDate": {
       "required": true,
       "type": "date"
     },
-    "LawNumber": {
+    "lawNumber": {
       "type": "string"
     },
-    "AdditionalImages": {
+    "additionalImages": {
       "collection": "file",
       "via": "related",
       "plugin": "upload",
       "required": false
     },
-    "Category": {
+    "category": {
       "model": "report-category"
     },
-    "Slug": {
+    "slug": {
       "type": "uid",
-      "targetField": "Title"
+      "targetField": "title"
     }
   }
 }

--- a/api/team-member/models/team-member.settings.json
+++ b/api/team-member/models/team-member.settings.json
@@ -16,27 +16,27 @@
     "comment": ""
   },
   "attributes": {
-    "Description": {
+    "content": {
       "required": true,
       "type": "richtext"
     },
-    "Twitter": {
+    "twitter": {
       "unique": true,
       "type": "string"
     },
-    "Instagram": {
+    "instagram": {
       "unique": true,
       "type": "string"
     },
-    "LinkedIn": {
+    "linkedIn": {
       "unique": true,
       "type": "string"
     },
-    "Name": {
+    "name": {
       "type": "string",
       "required": true
     },
-    "Photo": {
+    "photo": {
       "model": "file",
       "via": "related",
       "plugin": "upload",


### PR DESCRIPTION
This also standardizes a couple of things which weren't standard on the API's:

* All titles are now string fields, not text
* All field names are lowercase. This is required because they were capitalized before, but `updated_at` and `created_at` were not, causing different schemes in the API responses, which need to be taken into account.
* Adds slug fields to all categorical models
* All markdown content in all main publication models is now called `content`. Previously it was called `summary` or `description` depending on the model.