### PR TITLE
Removes required attribute from relations

### DIFF
--- a/api/activity/models/Activity.settings.json
+++ b/api/activity/models/Activity.settings.json
@@ -41,8 +41,7 @@
       "type": "datetime"
     },
     "category": {
-      "model": "activity-category",
-      "required": true
+      "model": "activity-category"
     },
     "slug": {
       "type": "uid",

--- a/api/report/models/Report.settings.json
+++ b/api/report/models/Report.settings.json
@@ -57,8 +57,7 @@
       "required": false
     },
     "category": {
-      "model": "report-category",
-      "required": true
+      "model": "report-category"
     },
     "slug": {
       "type": "uid",


### PR DESCRIPTION
See https://trello.com/c/PoappGe3/68-remove-required-relations.

There's a bug in strapi right now which causes creating an entity with a relation marked as `required` to fail. We are disabling the validation until that's fixed.